### PR TITLE
Added start script because other start command was not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 		"node": ">=10"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava",
+		"start": "node ui"
 	},
 	"files": [
 		"cli.js",


### PR DESCRIPTION
Hey, the command you'd included in your tutorial was not starting the app. Windows did not recognize the command. Adding a start script and starting the app using `npm start` worked. 